### PR TITLE
Correct link to source.

### DIFF
--- a/supplement.qmd
+++ b/supplement.qmd
@@ -13,7 +13,7 @@ toc: true
 toc-depth: 2
 code-fold: true
 code-tools: 
-    source: https://github.com/rpsychologist/gaming-causal-inference-paper/index.qmd
+    source: https://github.com/rpsychologist/gaming-causal-inference-paper/supplement.qmd
 html-math-method: katex
 format:
     html: 


### PR DESCRIPTION
I was checking out your publication from twitter and noticed the link to the source for the Quarto doc isn't correct. This should fix it.